### PR TITLE
Fix object plotting bug

### DIFF
--- a/when-to-see-objects.py
+++ b/when-to-see-objects.py
@@ -87,8 +87,6 @@ ax = [ax]
 bestday = {}
 
 for cnt, name in enumerate(stats["target"].unique()):
-    if "oo" in name:
-        continue
 
     df = stats[stats["target"] == name].sort_values("date")
 
@@ -104,7 +102,7 @@ for cnt, name in enumerate(stats["target"].unique()):
         "lw": 1 if name in FIXED_TARGETS else 2,
     }
 
-    if "oo" in name:
+    if name.lower() == "moon":
         kwargs["lw"] = 3
         kwargs["alpha"] = 0.5
 
@@ -122,11 +120,12 @@ for a in ax:
     a.grid(True, which="major", ls="--", alpha=0.4)
     # a.legend()
 
-json.dump(
-    bestday,
-    open("bestday.json", "w"),
-    indent=4,
-)
+with open("bestday.json", "w") as f:
+    json.dump(
+        bestday,
+        f,
+        indent=4,
+    )
 
 ax[0].set_ylabel("Altitude (degrees)")
 


### PR DESCRIPTION
## Summary
- ensure all objects (e.g. `M100`) are plotted by removing overly broad skip check
- style the Moon separately when present
- write `bestday.json` using a context manager

## Testing
- `python -m py_compile when-to-see-objects.py`